### PR TITLE
Correct logic in NotificationServiceImpl class notifyInternal method allowing POST I/O errors to go undetected

### DIFF
--- a/src/main/java/org/energyos/espi/common/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/org/energyos/espi/common/service/impl/NotificationServiceImpl.java
@@ -130,10 +130,14 @@ public class NotificationServiceImpl implements NotificationService {
 	private void notifyInternal(String thirdPartyNotificationURI,
 			BatchList batchList) {
 
-		try {
-			restTemplate.postForLocation(thirdPartyNotificationURI, batchList);
-		} catch (Exception e) {
-			// Do nothing
+		if(thirdPartyNotificationURI != null){
+			try {
+				restTemplate.postForLocation(thirdPartyNotificationURI, batchList);
+			} catch (Exception e) {
+				System.out
+				.printf("NotificationServiceImpl: notifyInternal - POST for %s caused an %s Exception\n",
+						thirdPartyNotificationURI, e.getMessage());
+			}
 		}
 	}
 


### PR DESCRIPTION
1) Add Exception processing to notifyInternal method
2) Test for null thirdPartyNotificationURI in notifyInternal method to avoid null UriTemplate exception when invoking restTemplate.postForLocation method