### PR TITLE
Update failing 'ServiceCategoryPersistenceTests' to use 'Column'

### DIFF
--- a/src/test/java/org/energyos/espi/common/domain/ServiceCategoryPersistenceTests.java
+++ b/src/test/java/org/energyos/espi/common/domain/ServiceCategoryPersistenceTests.java
@@ -16,7 +16,7 @@
 
 package org.energyos.espi.common.domain;
 
-import javax.persistence.Id;
+import javax.persistence.Column;
 
 import org.energyos.espi.common.support.TestUtils;
 import org.junit.Test;
@@ -26,6 +26,6 @@ public class ServiceCategoryPersistenceTests {
 	@Test
 	public void hasId() {
 		TestUtils.assertAnnotationPresent(ServiceCategory.class, "kind",
-				Id.class);
+				Column.class);
 	}
 }


### PR DESCRIPTION
Update failing 'ServiceCategoryPersistenceTests' to use 'Column' instead of 'Id' for annotation check,
related to this commit -> https://github.com/energyos/OpenESPI-Common-java/commit/21da3cf83267ed3432ba72d0571e693f0d7c8bc5