### PR TITLE
GBA AWS Sandbox database configuration and initialization changes

### DIFF
--- a/etc/initialize_GBA_AWS_Sandbox_databases.sh
+++ b/etc/initialize_GBA_AWS_Sandbox_databases.sh
@@ -8,13 +8,13 @@
 
 # drop/create databases 
 mysql --user=root --password=password < cleandatabases_dc.sql
-#mysql --user=root --password=password < cleandatabases_tp.sql
+mysql --user=root --password=password < cleandatabases_tp.sql
 
 # create tables 
-#mysql --user=root --password=password < thirdpartymysql.sql
+mysql --user=root --password=password < thirdpartymysql.sql
 mysql --user=root --password=password < datacustodianmysql.sql
 mysql --user=root --password=password < tokenstore.sql
 
 # prepopulate tables 
 mysql --user=root --password=password < prepopulatesql_dc.sql
-#mysql --user=root --password=password < prepopulatesql_tp.sql
+mysql --user=root --password=password < prepopulatesql_tp.sql

--- a/etc/prepopulatesql_tokenstore_GBA_AWS_Sandbox.sql
+++ b/etc/prepopulatesql_tokenstore_GBA_AWS_Sandbox.sql
@@ -141,9 +141,11 @@ LOCK TABLES `oauth_client_details` WRITE;
 SET sql_mode = 'PIPES_AS_CONCAT';
 
 SET @tpbaseurl = 'https://sandbox.greenbuttonalliance.org:8443';
+SET @certbaseurl = 'https://cert.greenbuttonalliance.org:8444';
 
 INSERT INTO `oauth_client_details` VALUES ('data_custodian',NULL,'secret','FB=3_19_32_33_34_35_36_37_38_41_44_45','client_credentials',NULL,'ROLE_DC_ADMIN',315360000,NULL,NULL,'FALSE'),('REGISTRATION_third_party',NULL,'secret','FB=36_40','client_credentials',NULL,'ROLE_TP_REGISTRATION',315360000,NULL,NULL,'FALSE'),('third_party',NULL,'secret','FB=1_3_4_5_13_14_39;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13,FB=1_3_4_5_13_14_15_39;IntervalDuration=900;BlockDuration=monthly;HistoryLength=13,FB=1_3_4_5_13_14_39;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13,FB=1_3_4_5_6_7_8_9_10_11_29_12_13_14_15_16_17_18_19_27_28_32_33_34_35_37_38_39_40_41_44;IntervalDuration=3600;BlockDuration=monthly;HistoryLength=13','authorization_code,refresh_token,client_credentials',
-@tpbaseurl || '/ThirdParty/espi/1_1/OAuthCallBack','ROLE_USER',315360000,630720000,NULL,'FALSE'),('third_party_admin',NULL,'secret','FB=34_35','client_credentials',NULL,'ROLE_TP_ADMIN',315360000,NULL,NULL,'FALSE'),('upload',NULL,'secret','FB=45','client_credentials',NULL,'ROLE_UL_ADMIN',315360000,NULL,NULL,'FALSE');
+@tpbaseurl || '/ThirdParty/espi/1_1/OAuthCallBack','ROLE_USER',315360000,630720000,NULL,'FALSE'),('third_party_admin',NULL,'secret','FB=34_35','client_credentials',NULL,'ROLE_TP_ADMIN',315360000,NULL,NULL,'FALSE'),('upload',NULL,'secret','FB=45','client_credentials',NULL,'ROLE_UL_ADMIN',315360000,NULL,NULL,'FALSE'),('gba_cmd_cert',NULL,'secret','FB=4_5_15;IntervalDuration=3600;BlockDuration=daily;HistoryLength=13','authorization_code,refresh_token,client_credentials',
+@certbaseurl || '/ThirdParty/espi/1_1/OAuthCallBack','ROLE_USER',315360000,630720000,NULL,'FALSE'),('gba_cmd_cert_admin',NULL,'secret','FB=4_5_15;IntervalDuration=3600;BlockDuration=daily;HistoryLength=13','client_credentials',NULL,'ROLE_TP_ADMIN',315360000,NULL,NULL,'FALSE'),('REGISTRATION_gba_cmd_cert',NULL,'secret','FB=36_40','client_credentials',NULL,'ROLE_TP_REGISTRATION',315360000,NULL,NULL,'FALSE');
 /*!40000 ALTER TABLE `oauth_client_details` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
1) Add 'gba_cmd_cert' client records to OAuth Tokenstore 'client_details' table
2) Add commands to initialize Third Party databases to initialize_GBA_AWS_Sandbox_databases script